### PR TITLE
docs: Fix simple typo, sucessful -> successful

### DIFF
--- a/channelstream/static/channelstream/channelstream.js
+++ b/channelstream/static/channelstream/channelstream.js
@@ -867,7 +867,7 @@ class ChannelStreamRequest {
     };
 
     /**
-     * Placeholder for sucessful response handler
+     * Placeholder for successful response handler
      * @param request
      * @param respText
      */


### PR DESCRIPTION
There is a small typo in channelstream/static/channelstream/channelstream.js.

Should read `successful` rather than `sucessful`.

